### PR TITLE
Optimize column fix in DataStore

### DIFF
--- a/backend/DataStore.py
+++ b/backend/DataStore.py
@@ -335,25 +335,16 @@ class DataStore:
         Registration Sheet Columns:
         Timestamp | Email | Name | Choice | Teacher Period | Club
         """
+        money_form_columns = ["Timestamp", "Email", "Money Raised", "Honesty Statement"]
+        registration_form_columns = ["Timestamp", "Email", "Name", "Choice", "Teacher", "Period", "Club"]
+
         if sheet.title == "MoneyForm":
-            sheet.update(
-                "A1:D1",
-                [["Timestamp", "Email", "Money Raised", "Honesty Statement"]],
-            )
+            current_columns = sheet.row_values(1)
+            if current_columns != money_form_columns:
+                sheet.update("A1:D1", [money_form_columns])
         elif sheet.title == "RegistrationForm":
-            sheet.update(
-                "A1:G1",
-                [
-                    [
-                        "Timestamp",
-                        "Email",
-                        "Name",
-                        "Choice",
-                        "Teacher",
-                        "Period",
-                        "Club",
-                    ]
-                ],
-            )
+            current_columns = sheet.row_values(1)
+            if current_columns != registration_form_columns:
+                sheet.update("A1:G1", [registration_form_columns])
         else:
             raise ValueError("Invalid sheet name provided.")


### PR DESCRIPTION
Add a check in the `_fix_column_names` method to verify if the column names are already correct before updating them.

* Create centralized lists of column names for both `MoneyForm` and `RegistrationForm` sheets.
* Update the `_fix_column_names` method to use the centralized list of column names.
* Check the current column names before updating them to avoid unnecessary updates.

